### PR TITLE
STYLE: Add itkVirtualGetNameOfClassMacro + itkOverrideGetNameOfClassMacro

### DIFF
--- a/include/itkSWCMeshIO.h
+++ b/include/itkSWCMeshIO.h
@@ -79,7 +79,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SWCMeshIO, MeshIOBase);
+  itkOverrideGetNameOfClassMacro(SWCMeshIO);
 
   /*-------- This part of the interfaces deals with reading data. ----- */
 

--- a/include/itkSWCMeshIOFactory.h
+++ b/include/itkSWCMeshIOFactory.h
@@ -51,7 +51,7 @@ public:
   itkFactorylessNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(SWCMeshIOFactory, ObjectFactoryBase);
+  itkOverrideGetNameOfClassMacro(SWCMeshIOFactory);
 
   /** Register one factory of this type  */
   static void


### PR DESCRIPTION
Added two new macro's, intended to replace the old 'itkTypeMacro' and
'itkTypeMacroNoParent'.

The main aim is to be clearer about what those macro's do: add a virtual
'GetNameOfClass()' member function and override it. Unlike 'itkTypeMacro',
'itkOverrideGetNameOfClassMacro' does not have a 'superclass' parameter, as it
was not used anyway.

Note that originally 'itkTypeMacro' did not use its 'superclass' parameter
either, looking at commit 699b66cb04d410e555656828e8892107add38ccb, Will
Schroeder, June 27, 2001:
https://github.com/InsightSoftwareConsortium/ITK/blob/699b66cb04d410e555656828e8892107add38ccb/Code/Common/itkMacro.h#L331-L337
